### PR TITLE
Update list_filters.py

### DIFF
--- a/django_admin_multiple_choice_list_filter/list_filters.py
+++ b/django_admin_multiple_choice_list_filter/list_filters.py
@@ -16,7 +16,7 @@ class MultipleChoiceListFilter(admin.SimpleListFilter):
     def queryset(self, request, queryset):
         if request.GET.get(self.parameter_name):
             kwargs = {self.parameter_name: request.GET[self.parameter_name].split(',')}
-            queryset = queryset.filter(**kwargs)
+            queryset = queryset.filter(**kwargs).distinct()
         return queryset
 
     def value_as_list(self):


### PR DESCRIPTION
In case MultipleChoiceListFilter is used to filter ManyToManyField, duplicate entries could be returned in the queryset. Using 'distinct()' corrects this.